### PR TITLE
Add note to spendingHabits to check if date picker works

### DIFF
--- a/lib/components/SpendingHabits.js
+++ b/lib/components/SpendingHabits.js
@@ -32,3 +32,6 @@ export default class SpendingHabits extends Component {
     )
   }
 }
+
+//converter for date to milliseconds to test if date input works
+// http://www.epochconverter.com


### PR DESCRIPTION
Added a quick note to the spendingHabits component to link to a site that converts a date to moment milliseconds for the purpose of testing dates other than the current day